### PR TITLE
[fix] parse json body in server

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -588,12 +588,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mpcmf/mpcmf-core.git",
-                "reference": "e3fb6dc0a969e1d05c387be10d8219cd035c59cb"
+                "reference": "8a0f31fa58d795523b714a8a59ae580d41040aba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mpcmf/mpcmf-core/zipball/e3fb6dc0a969e1d05c387be10d8219cd035c59cb",
-                "reference": "e3fb6dc0a969e1d05c387be10d8219cd035c59cb",
+                "url": "https://api.github.com/repos/mpcmf/mpcmf-core/zipball/8a0f31fa58d795523b714a8a59ae580d41040aba",
+                "reference": "8a0f31fa58d795523b714a8a59ae580d41040aba",
                 "shasum": ""
             },
             "require": {
@@ -668,7 +668,7 @@
                 "issues": "https://github.com/greevex/mpcmf-core/issues?state=open",
                 "source": "https://github.com/greevex/mpcmf-core"
             },
-            "time": "2022-09-14T14:18:57+00:00"
+            "time": "2022-11-03T14:07:26+00:00"
         },
         {
             "name": "mpcmf/mpcmf-signal-handler",

--- a/src/apps/mpcmfWeb/commands/server/run.php
+++ b/src/apps/mpcmfWeb/commands/server/run.php
@@ -337,7 +337,7 @@ abstract class run
                         $slim = $app->slim();
                         $originApplication = $this->applicationInstance->getCurrentApplication();
                         $this->applicationInstance->setApplication($app);
-                        list($status, $headers, $body) = $slim->runRaw();
+                        [$status, $headers, $body] = $slim->runRaw();
                     } catch(\Exception $e) {
                         $errorMessage = "Exception: {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}\n{$e->getTraceAsString()}";
                         $this->output->writeln("<error>[CHILD:{$this->port}]</error> {$errorMessage}");
@@ -346,8 +346,6 @@ abstract class run
                         return;
                     }
 
-                    //$content = $slim->response->finalize();
-                    //\Slim\Http\Util::serializeCookies($content[1], $slim->response->cookies, $slim->settings);
                     $headers = $headers->all();
                     $this->applicationInstance->setApplication($originApplication);
 

--- a/src/apps/mpcmfWeb/commands/server/run.php
+++ b/src/apps/mpcmfWeb/commands/server/run.php
@@ -333,7 +333,7 @@ abstract class run
                     }
 
                     try {
-                        $app = $this->app($requestContent);
+                        $app = $this->app($prepareResponse['content']);
                         $slim = $app->slim();
                         $originApplication = $this->applicationInstance->getCurrentApplication();
                         $this->applicationInstance->setApplication($app);
@@ -410,7 +410,8 @@ abstract class run
             return [
                 'status' => false,
                 'response' => $response,
-                'request' => $request
+                'request' => $request,
+                'content' => $content,
             ];
         }
 
@@ -425,7 +426,8 @@ abstract class run
             return [
                 'status' => false,
                 'response' => $response,
-                'request' => $request
+                'request' => $request,
+                'content' => $content,
             ];
         }
 
@@ -494,6 +496,7 @@ abstract class run
         $contentType = $request->getHeaderLine('content-type');
         if (stripos($contentType, 'application/json') !== false) {
             $_POST = [];
+            $content = json_decode($content, true) ?? $content;
         } elseif (!preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
             parse_str($content, $_POST);
         } else {
@@ -516,7 +519,8 @@ abstract class run
         return [
             'status' => true,
             'response' => null,
-            'request' => $request
+            'request' => $request,
+            'content' => $content,
         ];
     }
 

--- a/src/apps/mpcmfWeb/system/application/webApplicationBase.php
+++ b/src/apps/mpcmfWeb/system/application/webApplicationBase.php
@@ -496,7 +496,7 @@ abstract class webApplicationBase
         if($isApiRequest) {
             $authorizationHeader = $request->headers('Authorization');
             if ($authorizationHeader !== null) {
-                [$tokenType, $accessToken] = preg_split('/\s+/', trim($authorizationHeader));
+                list($tokenType, $accessToken) = preg_split('/\s+/', trim($authorizationHeader));
                 if ($tokenType !== 'Bearer') {
                     $body = json_encode([
                         'status' => false,

--- a/src/apps/mpcmfWeb/system/application/webApplicationBase.php
+++ b/src/apps/mpcmfWeb/system/application/webApplicationBase.php
@@ -20,6 +20,7 @@ use mpcmf\system\helper\i18n\i18n;
 use mpcmf\system\helper\module\exception\modulePartsHelperException;
 use mpcmf\system\helper\system\profiler;
 use mpcmf\system\helper\system\systemStructure;
+use mpcmf\system\http\slimDriver;
 use mpcmf\system\pattern\singleton;
 use mpcmf\system\view\smartyDriver;
 use Slim\Exception\Stop;
@@ -642,7 +643,7 @@ abstract class webApplicationBase
      * @param null $instance
      * @param string|null $appKey
      *
-     * @return Slim
+     * @return slimDriver
      * @throws webApplicationException
      */
     public function slim($instance = null, $appKey = null)
@@ -660,7 +661,7 @@ abstract class webApplicationBase
                 throw new webApplicationException('Undefined required config sections: slim, name');
             }
 
-            self::$slimInstance[$appKey] = new Slim($config['slim']);
+            self::$slimInstance[$appKey] = new slimDriver($config['slim']);
             self::$slimInstance[$appKey]->setName($appKey);
             self::$slimInstance[$appKey]->add(new ContentTypes());
 

--- a/src/apps/mpcmfWeb/system/application/webApplicationBase.php
+++ b/src/apps/mpcmfWeb/system/application/webApplicationBase.php
@@ -23,6 +23,7 @@ use mpcmf\system\helper\system\systemStructure;
 use mpcmf\system\pattern\singleton;
 use mpcmf\system\view\smartyDriver;
 use Slim\Exception\Stop;
+use Slim\Middleware\ContentTypes;
 use Slim\Middleware\PrettyExceptions;
 use Slim\Route;
 use Slim\Slim;
@@ -495,7 +496,7 @@ abstract class webApplicationBase
         if($isApiRequest) {
             $authorizationHeader = $request->headers('Authorization');
             if ($authorizationHeader !== null) {
-                list($tokenType, $accessToken) = preg_split('/\s+/', trim($authorizationHeader));
+                [$tokenType, $accessToken] = preg_split('/\s+/', trim($authorizationHeader));
                 if ($tokenType !== 'Bearer') {
                     $body = json_encode([
                         'status' => false,
@@ -661,6 +662,7 @@ abstract class webApplicationBase
 
             self::$slimInstance[$appKey] = new Slim($config['slim']);
             self::$slimInstance[$appKey]->setName($appKey);
+            self::$slimInstance[$appKey]->add(new ContentTypes());
 
             set_error_handler(array('\Slim\Slim', 'handleErrors'));
 


### PR DESCRIPTION
this allows to use in controllers:
```
$params = $this->getSlim()->getBody();
``` 
insteadof
```
$request = $this->getSlim()->request();
$params = json_decode($request->getBody(), true);
```



slim has such ability "out-of-the-box" with content-type middleware: `$slim->add(new ContentTypes());` when using with `php -S` or `php-fpm`
our webserver does not.